### PR TITLE
Update config for use with schematic 24.2.1

### DIFF
--- a/MC2/dca_config.json
+++ b/MC2/dca_config.json
@@ -17,15 +17,19 @@
     "sidebar_col": "#191919"
   },
   "schematic": {
+    "global": {
+      "data_model_labels": "class_label"
+    },
     "manifest_generate": {
-      "output_format": "excel",
+      "output_format": "google_sheets",
       "use_annotations": false
     },
     "model_validate": {
       "restrict_rules": false
     },
     "model_submit": {
-      "use_schema_labels": false,
+      "table_column_names": "display_name",
+      "annotation_keys": "class_label",
       "table_manipulation": "upsert",
       "manifest_record_type": "table_and_file",
       "hide_blanks": false


### PR DESCRIPTION
Add "global" setting "data_model_labels": "class_label"

Add "table_column_names": "display_name" to "model_submit"

Add "annotation_keys": "class_label" to "model_submit"

Remove "use_schema_labels" from "model_submit"

Change "output_format" from "excel" to "google_sheets", under "manifest_generate" options